### PR TITLE
feat(hwid): send HWID (Hardware Device ID) and DeviceInfo headers with RemoteConfig requests

### DIFF
--- a/ClashX/Base.lproj/Main.storyboard
+++ b/ClashX/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -297,15 +297,15 @@
                                                 <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" translatesAutoresizingMaskIntoConstraints="NO" id="plI-7S-yCW">
                                                     <rect key="frame" x="20" y="10" width="392" height="20"/>
                                                     <clipView key="contentView" drawsBackground="NO" id="HHy-NP-pH6">
-                                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="392" height="20"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" spellingCorrection="YES" smartInsertDelete="YES" id="sjz-uN-XpL">
-                                                                <rect key="frame" x="0.0" y="0.0" width="377" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="392" height="20"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                <size key="minSize" width="377" height="20"/>
+                                                                <size key="minSize" width="392" height="20"/>
                                                                 <size key="maxSize" width="450" height="10000000"/>
                                                                 <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                             </textView>
@@ -319,7 +319,7 @@
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="OaY-Eu-ksx">
-                                                        <rect key="frame" x="377" y="0.0" width="15" height="20"/>
+                                                        <rect key="frame" x="376" y="0.0" width="16" height="20"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                 </scrollView>
@@ -426,15 +426,15 @@
                                                 <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vfh-gi-qYe">
                                                     <rect key="frame" x="20" y="40" width="392" height="100"/>
                                                     <clipView key="contentView" drawsBackground="NO" id="bzV-Hc-3eJ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="377" height="100"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="392" height="100"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" spellingCorrection="YES" smartInsertDelete="YES" id="JDw-FW-A2o">
-                                                                <rect key="frame" x="0.0" y="0.0" width="377" height="100"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="392" height="100"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                <size key="minSize" width="377" height="100"/>
+                                                                <size key="minSize" width="392" height="100"/>
                                                                 <size key="maxSize" width="450" height="10000000"/>
                                                                 <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                             </textView>
@@ -448,7 +448,7 @@
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="dbQ-aI-3eA">
-                                                        <rect key="frame" x="377" y="0.0" width="15" height="100"/>
+                                                        <rect key="frame" x="376" y="0.0" width="16" height="100"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                 </scrollView>
@@ -1180,6 +1180,18 @@
                                     <fragment content="#bc-ignore!"/>
                                 </attributedString>
                             </textField>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vnd-Vd-OzJ">
+                                <rect key="frame" x="18" y="7" width="419" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" alignment="center" title="HWID" id="mdA-fp-ZrW">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <attributedString key="userComments">
+                                    <fragment content="#bc-ignore!"/>
+                                </attributedString>
+                            </textField>
                         </subviews>
                         <constraints>
                             <constraint firstItem="prU-ck-7Na" firstAttribute="centerX" secondItem="JCR-G0-H6V" secondAttribute="centerX" id="6sZ-T8-xec"/>
@@ -1200,12 +1212,13 @@
                     <connections>
                         <outlet property="buildTimeLabel" destination="qla-PJ-sDO" id="zce-NL-ftN"/>
                         <outlet property="coreVersionLabel" destination="dDI-8K-OOb" id="vHu-Qr-E1k"/>
+                        <outlet property="hwidLabel" destination="Vnd-Vd-OzJ" id="XGN-yU-qxT"/>
                         <outlet property="versionLabel" destination="gP8-vp-ASP" id="2V8-vb-VKi"/>
                     </connections>
                 </viewController>
                 <customObject id="oHh-a0-cAY" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-32" y="744"/>
+            <point key="canvasLocation" x="-32.5" y="744"/>
         </scene>
         <!--Remote Configs-->
         <scene sceneID="lXv-k7-YEi">

--- a/ClashX/General/Managers/RemoteConfigManager.swift
+++ b/ClashX/General/Managers/RemoteConfigManager.swift
@@ -8,10 +8,16 @@
 
 import Alamofire
 import Cocoa
+import IOKit
+import Foundation
+import Darwin
 
 class RemoteConfigManager {
     var configs: [RemoteConfigModel] = []
     var refreshActivity: NSBackgroundActivityScheduler?
+    
+    private static var cachedHWID: String?
+    private static var cachedDeviceModel: String?
 
     static let shared = RemoteConfigManager()
 
@@ -142,6 +148,13 @@ class RemoteConfigManager {
             return
         }
         urlRequest.cachePolicy = .reloadIgnoringCacheData
+        
+        let deviceHeaders = getDeviceHeaders()
+        for (key, value) in deviceHeaders {
+            urlRequest.addValue(value, forHTTPHeaderField: key)
+        }
+        
+        Logger.log("[getRemoteConfigData] Adding device headers: \(deviceHeaders)", level: .info)
 
         AF.request(urlRequest)
             .validate()
@@ -227,6 +240,58 @@ class RemoteConfigManager {
         }
 		
         return (NSApplication.shared.delegate as? AppDelegate)?.clashProcess.verify(kConfigFolderPath, confFilePath: confPath)
+    }
+    
+    static func getDeviceHeaders() -> [String: String] {
+    
+        let hwid = getHardwareUUID()
+        
+        let processInfo = ProcessInfo.processInfo
+        let osVersion = "\(processInfo.operatingSystemVersion.majorVersion).\(processInfo.operatingSystemVersion.minorVersion).\(processInfo.operatingSystemVersion.patchVersion)"
+        let deviceModel = getDeviceModel()
+        
+        return [
+            "x-hwid": hwid,
+            "x-device-os": "macOS",
+            "x-ver-os": osVersion,
+            "x-device-model": deviceModel
+        ]
+    }
+    
+    static func getHardwareUUID() -> String {
+        if let cachedID = cachedHWID {
+            return cachedID
+        }
+        
+        let platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
+        defer { IOObjectRelease(platformExpert) }
+        
+        if let uuid = IORegistryEntryCreateCFProperty(platformExpert, "IOPlatformUUID" as CFString, kCFAllocatorDefault, 0) {
+            if let uuidString = uuid.takeUnretainedValue() as? String {
+                cachedHWID = uuidString
+                return uuidString
+            }
+        }
+        
+        let fallbackUUID = UUID().uuidString
+        cachedHWID = fallbackUUID
+        Logger.log("[Hardware] Could not retrieve device hardware UUID, using generated UUID", level: .warning)
+        return fallbackUUID
+    }
+    
+    static func getDeviceModel() -> String {
+        if let cachedModel = cachedDeviceModel {
+            return cachedModel
+        }
+        
+        var size = 0
+        sysctlbyname("hw.model", nil, &size, nil, 0)
+        var model = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.model", &model, &size, nil, 0)
+        
+        let modelString = String(cString: model)
+        cachedDeviceModel = modelString
+        return modelString
     }
 
     static func showAdd() {

--- a/ClashX/ViewControllers/AboutViewController.swift
+++ b/ClashX/ViewControllers/AboutViewController.swift
@@ -12,7 +12,8 @@ class AboutViewController: NSViewController {
     @IBOutlet var versionLabel: NSTextField!
     @IBOutlet var buildTimeLabel: NSTextField!
     @IBOutlet var coreVersionLabel: NSTextField!
-
+    @IBOutlet var hwidLabel: NSTextField!
+    
     lazy var clashCoreVersion: String = {
         return Bundle.main.infoDictionary?["coreVersion"] as? String ?? "unknown"
     }()
@@ -35,10 +36,13 @@ class AboutViewController: NSViewController {
 
         let version = AppVersionUtil.currentVersion
         let build = AppVersionUtil.currentBuild
+        let hwid = RemoteConfigManager.getHardwareUUID()
+        
 
         versionLabel.stringValue = "Version: \(version) (\(build))"
         coreVersionLabel.stringValue = "Meta Core: \(clashCoreVersion)"
         buildTimeLabel.stringValue = "\(commit)-\(branch) \(buildTime)"
+        hwidLabel.stringValue = "HWID: \(hwid)"
     }
 
     override func viewWillAppear() {


### PR DESCRIPTION
**Hi there!**

Here i tried to implement sending HWID and other headers, which can be used by panels like Remnawave, Marzban, 3X-UI and others.

[Remnawave](https://github.com/remnawave/panel) is currently supports HWID limitations in dev branch.

Client apps, which already support sending HWIDs:
– [Happ](https://happ.su)


Currently we are trying to implement HWID common standard, which apps and panels will use.

Standard specs can be found here: https://remna.st/features/hwid-device-limit#for-app-developers

Also i have added a HWID in AboutView screen, end users can copy it and send to proxy providers.

![telegram-cloud-photo-size-2-5460963364411929151-y](https://github.com/user-attachments/assets/01b33d70-a112-4a04-871e-6c0350c2f000)


I have tested build on latest macOS version, on MacBook Pro with M-chip.

![CleanShot 2025-04-11 at 20 35 49@2x](https://github.com/user-attachments/assets/cb0311a2-385c-49c1-b4fb-f370db4ffddb)


