### PR TITLE
fix macOS 26 crash

### DIFF
--- a/ClashX/General/Utils/Command.swift
+++ b/ClashX/General/Utils/Command.swift
@@ -16,19 +16,25 @@ struct Command {
         var output = ""
 
         let task = Process()
-        task.launchPath = cmd
+
+        task.executableURL = URL(fileURLWithPath: cmd)
         task.arguments = args
 
         let outpipe = Pipe()
         task.standardOutput = outpipe
 
-        task.launch()
+        do {
+            try task.run()
+            task.waitUntilExit()
 
-        task.waitUntilExit()
-        let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
-        if let string = String(data: outdata, encoding: .utf8) {
-            output = string.trimmingCharacters(in: .newlines)
+            let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
+            if let string = String(data: outdata, encoding: .utf8) {
+                output = string.trimmingCharacters(in: .newlines)
+            }
+        } catch {
+            print("Error running command: \(error)")
         }
+
         return output
     }
 }

--- a/install_dependency.sh
+++ b/install_dependency.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 set -e
 
+if [ ! -d "clash.meta" ]; then
+    echo "Downloading mihomo..."
+    mkdir clash.meta
+    # arm64
+    curl -s https://api.github.com/repos/MetaCubeX/mihomo/releases/latest \
+     | grep "browser_download_url.*mihomo-darwin-arm64-v.*gz" \
+     | cut -d '"' -f 4 \
+     | xargs curl -L -o clash.meta/mihomo-darwin-arm64.gz
+
+     # amd64
+    curl -s https://api.github.com/repos/MetaCubeX/mihomo/releases/latest \
+     | grep "browser_download_url.*mihomo-darwin-amd64-v.*gz" \
+     | cut -d '"' -f 4 \
+     | xargs curl -L -o clash.meta/mihomo-darwin-amd64.gz
+
+    echo "Download complete."
+fi
+
 echo "Unzip core files"
 cd clash.meta
 ls


### PR DESCRIPTION
1. fix crash on macOS 26
2.  modify `install_dependency.sh` to support local develop