### PR TITLE
Add DMG Packaging to GitHub Actions Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,13 +61,19 @@ jobs:
     - name: create zip
       run: ditto -c -k --sequesterRsrc --keepParent archive/ClashX.xcarchive/Products/Applications/ClashX\ Meta.app "ClashX Meta.zip"
 
+    - name: create dmg
+      run: |
+        npm install --global create-dmg
+        create-dmg --overwrite --no-version-in-filename --no-code-sign --dmg-title "ClashX Meta" "archive/ClashX.xcarchive/Products/Applications/ClashX Meta.app" .
 
     - name: upload Artifact
       uses: actions/upload-artifact@v4
       if: "!startsWith(github.ref, 'refs/tags/')"
       with:
-        name: "ClashX Meta.zip"
-        path: "*.zip"
+        name: "ClashX Meta"
+        path: |
+          "*.zip"
+          "*.dmg"
 
     - name: load sparkle-repo
       uses: actions/checkout@v4
@@ -113,4 +119,5 @@ jobs:
         generate_release_notes: true
         files: |
           ClashX Meta.zip
+          ClashX Meta.dmg
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,8 @@ jobs:
       with:
         name: "ClashX Meta"
         path: |
-          "*.zip"
-          "*.dmg"
+          *.zip
+          *.dmg
 
     - name: load sparkle-repo
       uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds DMG packaging to the GitHub Actions build workflow to align with standard macOS software conventions.