### PR TITLE
fix: detect helper binary mismatch on app auto-update

### DIFF
--- a/ClashX/General/Managers/PrivilegedHelperManager.swift
+++ b/ClashX/General/Managers/PrivilegedHelperManager.swift
@@ -161,11 +161,26 @@ class PrivilegedHelperManager {
             reply(false)
             return
         }
-        let helperFileExists = FileManager.default.fileExists(atPath: "/Library/PrivilegedHelperTools/\(PrivilegedHelperManager.machServiceName)")
+        let installedHelperPath = "/Library/PrivilegedHelperTools/\(PrivilegedHelperManager.machServiceName)"
+        let helperFileExists = FileManager.default.fileExists(atPath: installedHelperPath)
         if !helperFileExists {
             reply(false)
             return
         }
+
+        // Check if the installed helper binary differs from the bundled one.
+        // When the app auto-updates, the bundled helper binary may have changed
+        // but the version string in Info.plist may not have been bumped.
+        // This binary comparison catches those cases so reinstall is triggered
+        // even when CFBundleShortVersionString remains the same.
+        if let bundledData = try? Data(contentsOf: helperURL),
+           let installedData = try? Data(contentsOf: URL(fileURLWithPath: installedHelperPath)),
+           bundledData != installedData {
+            Logger.log("helper binary mismatch, needs reinstall (bundled: \(bundledData.count) bytes, installed: \(installedData.count) bytes)", level: .info)
+            reply(false)
+            return
+        }
+
         let timeout: TimeInterval = helperFileExists ? 15 : 5
         let time = Date()
         
@@ -205,6 +220,7 @@ extension PrivilegedHelperManager {
 
         let result = installHelperDaemon()
         if case .success = result {
+            checkInstall()
             return
         }
         result.alertAction()

--- a/ProxyConfigHelper/Helper-Info.plist
+++ b/ProxyConfigHelper/Helper-Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>com.west2online.ClashX.ProxyConfigHelper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8</string>
+	<string>2.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and identifier &quot;com.west2online.ClashX&quot; and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MEWHFZ92DY)</string>


### PR DESCRIPTION
## Problem

When ClashX Meta auto-updates (e.g., v1.4.35 → v1.4.36 which introduced `refactor: async xpc helper`), the bundled ProxyConfigHelper binary changes but the `CFBundleShortVersionString` in `Helper-Info.plist` may not be bumped. This causes the version check in `getHelperStatus()` to pass even though the binaries differ, leaving the old installed helper in place. The old helper cannot serve the new XPC protocol, resulting in:

```
NSCocoaErrorDomain Code=4097
"connection to service named com.xxx.ClashX.ProxyConfigHelper"
```

Followed by a 15-second timeout. The app's menu bar icon shows but clicking it does nothing — the entire interaction layer hangs waiting for the helper.

## Root Cause

The `getHelperStatus()` method only compares `CFBundleShortVersionString` strings. When the helper binary changes but the developer forgets to bump the plist version, the check passes. The user then gets stuck with an old helper that can't talk to the new app.

In v1.4.36 specifically, commit `fbe3ecc` (`refactor: async xpc helper`) changed the XPC communication pattern without updating the helper's version string, breaking all existing installations that had the old helper from v1.4.35.

## Changes

### 1. Binary content comparison as fallback (`PrivilegedHelperManager.swift:170-182`)

Before attempting the XPC connection, compare the bundled helper binary against the installed one using `Data(contentsOf:)`. If they differ, immediately trigger reinstall without waiting for the 15-second XPC timeout.

This catches the common case where:
- App auto-updates → bundled helper changes
- Helper-Info.plist version string was not bumped
- Old installed helper is incompatible with new XPC protocol

### 2. Re-verify after successful install (`PrivilegedHelperManager.swift:222-224`)

After `SMJobBless` succeeds, call `checkInstall()` again to verify the helper is working and properly set `isHelperCheckFinished`. Previously the method returned immediately without re-verification.

### 3. Bump helper version (`Helper-Info.plist`)

Updated `CFBundleShortVersionString` from `1.8` to `2.0` and `CFBundleVersion` from `3` to `4`.

## Testing (macOS 26.3.1, ClashX Meta v1.4.36)

| # | Scenario | Result |
|---|----------|--------|
| 1 | Different sizes (415KB vs 569KB — **the exact bug scenario**) | ✅ Mismatch detected |
| 2 | Same size, different content | ✅ Mismatch detected |
| 3 | Identical content | ✅ Correctly matches |
| 4 | `try?` returns nil (permission denied) | ✅ Skips gracefully |
| 5 | File doesn't exist (fresh install) | ✅ Existing logic handles |
| 6 | Real bundled vs installed (post-fix) | ✅ MATCH — 569,088 bytes |

Performance: `Data(contentsOf:)` for 569KB takes <1ms on Apple Silicon.

## Related

Fixes #189
