### PR TITLE
fix: helper binary update check, stream readTimeout, net-speed reset

### DIFF
--- a/ClashX/AppDelegate.swift
+++ b/ClashX/AppDelegate.swift
@@ -226,13 +226,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 	
     func setupData() {
-        ConfigManager.shared
-            .showNetSpeedIndicatorObservable.skip(1)
-            .bind { _ in
-                Task { @MainActor in
-                    ApiRequest.shared.resetStreamApi(for: .traffic)
-                }
-            }.disposed(by: disposeBag)
+        // Show/hide menu-bar speed is UI-only (StatusItemView.showSpeedContainer).
+        // Do not reset /traffic stream here: cancel+reconnect is unnecessary and was
+        // mis-detected as core crash in streamDidDisconnect.
+        //
+        // ConfigManager.shared
+        //     .showNetSpeedIndicatorObservable.skip(1)
+        //     .bind { _ in
+        //         Task { @MainActor in
+        //             ApiRequest.shared.resetStreamApi(for: .traffic)
+        //         }
+        //     }.disposed(by: disposeBag)
 
         ProxyManager.shared
             .stateDidChange

--- a/ClashX/General/ApiRequest.swift
+++ b/ClashX/General/ApiRequest.swift
@@ -11,6 +11,7 @@ import Cocoa
 import SwiftyJSON
 import Foundation
 import NIOHTTP1
+import AsyncHTTPClient
 
 protocol ApiRequestStreamDelegate: AnyObject {
     func didUpdateTraffic(up: Int, down: Int) async
@@ -658,7 +659,6 @@ extension ApiRequest {
     @MainActor
     private func streamDidConnect(_ type: StreamType) async {
         streamRetryDelays[type] = 1
-        Logger.log("\(type)Stream did Connect", level: .debug)
 
         if type == .traffic {
             didTrafficStreamEverConnect = true
@@ -703,12 +703,24 @@ extension ApiRequest {
             }
         }
         
-        if let err = error, (err as? HTTPParserError) != .invalidEOFState {
-            Logger.log(err.localizedDescription, level: .error)
+        if let err = error,
+           (err as? HTTPParserError) != .invalidEOFState,
+           !(err is CancellationError) {
+            Logger.log("stream error type=\(type) \(Self.describeStreamError(err))", level: .error)
         }
 
-		Logger.log("\(type)Stream did disconnect", level: .debug)
 		scheduleRetry(for: type)
+	}
+
+	private static func describeStreamError(_ error: Error) -> String {
+		var parts: [String] = ["desc=\(error)"]
+		let ns = error as NSError
+		parts.append("domain=\(ns.domain)")
+		parts.append("code=\(ns.code)")
+		if let http = error as? HTTPClientError {
+			parts.append("httpClientError=\(http)")
+		}
+		return parts.joined(separator: " | ")
 	}
 
 	private func streamDidReceiveMessage(_ type: StreamType, text: String) async {

--- a/ClashX/General/ApiRequestTransport.swift
+++ b/ClashX/General/ApiRequestTransport.swift
@@ -24,6 +24,21 @@ enum ApiRequestTransport {
     static var requestTimeout: TimeAmount = .seconds(30)
     private static let maxPendingStreamBytes = 1 * 1024 * 1024
     private static let maxStreamLineBytes = 64 * 1024
+
+    /// Dedicated client for /traffic|/logs|/memory chunked streams.
+    /// `timeout.read = nil` means no idle read timeout (sparse /logs must not die at ~90s).
+    /// Overall request still has a long deadline via `execute(..., timeout:)`.
+    private static let streamHTTPClient: HTTPClient = {
+        var configuration = HTTPClient.Configuration()
+        configuration.timeout = .init(
+            connect: .seconds(10),
+            read: nil
+        )
+        return HTTPClient(
+            eventLoopGroupProvider: .singleton,
+            configuration: configuration
+        )
+    }()
     
     // Debug
     static var debugUseHttpApi: Bool = false
@@ -218,7 +233,12 @@ enum ApiRequestTransport {
                     case .failure(let error):
                         throw error
                     case .request(let request):
-                        let response = try await performClientRequest(request, shouldValidate: shouldValidate, timeout: .hours(24))
+                        let response = try await performClientRequest(
+                            request,
+                            shouldValidate: shouldValidate,
+                            timeout: .hours(24),
+                            client: streamHTTPClient
+                        )
 
                         for try await buffer in response.body {
                             if Task.isCancelled {
@@ -358,9 +378,10 @@ enum ApiRequestTransport {
     private static func performClientRequest(
         _ clientRequest: HTTPClientRequest,
         shouldValidate: Bool = false,
-        timeout: TimeAmount? = nil
+        timeout: TimeAmount? = nil,
+        client: HTTPClient = .shared
     ) async throws -> HTTPClientResponse {
-        let response = try await HTTPClient.shared.execute(clientRequest, timeout: timeout ?? requestTimeout)
+        let response = try await client.execute(clientRequest, timeout: timeout ?? requestTimeout)
 
         if shouldValidate && !(200 ..< 300).contains(response.status.code) {
             throw RequestError.statusCode(Int(response.status.code))

--- a/ClashX/General/Managers/PrivilegedHelperManager.swift
+++ b/ClashX/General/Managers/PrivilegedHelperManager.swift
@@ -267,6 +267,13 @@ final class PrivilegedHelperManager {
             } else {
                 return .needUpdate
             }
+            // Same CFBundleShortVersionString can still ship different binaries (rebuilds,
+            // arch slice changes, local Debug vs release). Version-only checks skip install
+            // in those cases; compare on-disk content so SMJobBless/legacy install re-runs.
+            if helperBinaryDiffersFromBundle(installed: helperInstalledURL, bundled: helperURL) {
+                Logger.log("helper binary differs from app bundle, need update", level: .info)
+                return .needUpdate
+            }
         } else {
             return .noFound
         }
@@ -297,6 +304,16 @@ final class PrivilegedHelperManager {
             group.cancelAll()
             return status
         }
+    }
+
+    /// Returns true when installed helper bytes differ from the one embedded in the app,
+    /// or either file cannot be read (treat as needing reinstall).
+    private func helperBinaryDiffersFromBundle(installed: URL, bundled: URL) -> Bool {
+        guard let bundledData = try? Data(contentsOf: bundled),
+              let installedData = try? Data(contentsOf: installed) else {
+            return true
+        }
+        return bundledData != installedData
     }
 
     @MainActor

--- a/ProxyConfigHelper/MetaTask.swift
+++ b/ProxyConfigHelper/MetaTask.swift
@@ -145,11 +145,13 @@ class MetaTask: NSObject {
             ])
         }
 
-        guard let data: Data = try? await run(
+        // SubprocessFoundation DataOutput is not linked in this target; use string output.
+        guard let output: String = try? await run(
             .name("curl"),
             arguments: Arguments(args),
-            output: .data(limit: 65536)
+            output: .string(limit: 65536)
         ).standardOutput,
+              let data = output.data(using: .utf8),
               let str = try? JSONDecoder().decode(MetaCurl.self, from: data),
               (str.hello == "clash.meta" || str.hello == "mihomo") else {
             return false


### PR DESCRIPTION
## Summary

- **Helper**: after version string matches, compare installed helper bytes with the embedded binary; differ → `needUpdate` / reinstall.
- **Streams**: dedicated `HTTPClient` for `/traffic`, `/logs`, `/memory` with `timeout.read = nil` (fixes ~90s `HTTPClientError.readTimeout` on sparse logs).
- **Menu bar speed toggle**: stop `resetStreamApi(for: .traffic)` — show/hide is UI-only; cancel/reconnect was unnecessary and could contribute to false core-crash UX (see #211).
- **Logging**: only log real stream failures (skip cancel / invalid EOF).
- **MetaTask**: Subprocess collect stdout as string (helper target has no DataOutput).

No menu layout / status-item spacing changes.

## Test plan

- [ ] Same version, different helper binary → install prompt; after install, md5 matches bundle; relaunch quiet.
- [ ] log-level warning, idle >2 min → no periodic readTimeout stream errors; menu speed still updates.
- [ ] Toggle show network indicator → no “Core Process Crashed” alert from that path.
- [ ] Core starts; system proxy / TUN work after helper reinstall if prompted.