### PR TITLE
fix: prevent repeated helper installation prompts on macOS Tahoe

### DIFF
--- a/ClashX.xcodeproj/project.pbxproj
+++ b/ClashX.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		01E908FC2FEE786F00C95A3A /* Subprocess in Frameworks */ = {isa = PBXBuildFile; productRef = 01E908FB2FEE786F00C95A3A /* Subprocess */; };
 		01E908FE2FEE787900C95A3A /* Subprocess in Frameworks */ = {isa = PBXBuildFile; productRef = 01E908FD2FEE787900C95A3A /* Subprocess */; };
 		01E909002FEF838700C95A3A /* ExitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E908FF2FEF838700C95A3A /* ExitManager.swift */; };
+		7C58E581D12527A98FA19314 /* HelperXPCSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5346172328EAF830F478CC79 /* HelperXPCSecurity.swift */; };
 		01EF33602B98D03B00D1DBD9 /* ProxyConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EF335F2B98D03B00D1DBD9 /* ProxyConfigHelper.swift */; };
 		01EF33622B98D3A700D1DBD9 /* ProxyConfigRemoteProcessProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EF33612B98D3A700D1DBD9 /* ProxyConfigRemoteProcessProtocol.swift */; };
 		01EF33642B98D71600D1DBD9 /* ProxyConfigRemoteProcessProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EF33612B98D3A700D1DBD9 /* ProxyConfigRemoteProcessProtocol.swift */; };
@@ -292,6 +293,7 @@
 		01E33AB129B5BF4200FD1006 /* NSColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+Extension.swift"; sourceTree = "<group>"; };
 		01E33AB429B5C5E300FD1006 /* menu_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "menu_icon@2x.png"; sourceTree = "<group>"; };
 		01E908FF2FEF838700C95A3A /* ExitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitManager.swift; sourceTree = "<group>"; };
+		5346172328EAF830F478CC79 /* HelperXPCSecurity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperXPCSecurity.swift; sourceTree = "<group>"; };
 		01EF335F2B98D03B00D1DBD9 /* ProxyConfigHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyConfigHelper.swift; sourceTree = "<group>"; };
 		01EF33612B98D3A700D1DBD9 /* ProxyConfigRemoteProcessProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyConfigRemoteProcessProtocol.swift; sourceTree = "<group>"; };
 		01EF58AB2FF55DEC00432213 /* FileWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileWatcher.swift; sourceTree = "<group>"; };
@@ -859,6 +861,7 @@
 				019A239528657A7A00AE5698 /* main.swift */,
 				01EF33612B98D3A700D1DBD9 /* ProxyConfigRemoteProcessProtocol.swift */,
 				013B21FC2F7EC4F9009B30CB /* ProxyConfigHelperXPCTransport.swift */,
+				5346172328EAF830F478CC79 /* HelperXPCSecurity.swift */,
 				01EF335F2B98D03B00D1DBD9 /* ProxyConfigHelper.swift */,
 				0162E74E2864B819007218A6 /* MetaTask.swift */,
 				01CA6BBF2B6A1B3100E386D6 /* MetaServer.swift */,
@@ -1155,6 +1158,7 @@
 			files = (
 				01EF33622B98D3A700D1DBD9 /* ProxyConfigRemoteProcessProtocol.swift in Sources */,
 				0162E74F2864B819007218A6 /* MetaTask.swift in Sources */,
+				7C58E581D12527A98FA19314 /* HelperXPCSecurity.swift in Sources */,
 				01EF33602B98D03B00D1DBD9 /* ProxyConfigHelper.swift in Sources */,
 				019A239628657A7A00AE5698 /* main.swift in Sources */,
 				013B21FF2F7FB18A009B30CB /* Task+Sleep.swift in Sources */,

--- a/ProxyConfigHelper/HelperXPCSecurity.swift
+++ b/ProxyConfigHelper/HelperXPCSecurity.swift
@@ -1,0 +1,75 @@
+//
+//  HelperXPCSecurity.swift
+//  com.metacubex.ClashX.ProxyConfigHelper
+//
+
+import Foundation
+import Security
+import os.log
+
+enum HelperXPCSecurity {
+	// Ad-hoc releases are validated by their signing identifier.
+	private static let clientCodeSigningRequirement = #"identifier "com.metacubex.ClashX.meta""#
+
+	private struct RequirementState {
+		let requirement: SecRequirement?
+		let status: OSStatus
+	}
+
+	private static let requirementState: RequirementState = {
+		var requirement: SecRequirement?
+		let status = SecRequirementCreateWithString(
+			clientCodeSigningRequirement as CFString,
+			[],
+			&requirement
+		)
+		return RequirementState(requirement: requirement, status: status)
+	}()
+
+	static func isValid(processIdentifier: pid_t) -> Bool {
+		// NSRunningApplication.bundleIdentifier can be unavailable when inspected
+		// from a root launch daemon. Resolve the live process through Security.framework.
+		let attributes = [
+			kSecGuestAttributePid as String: NSNumber(value: processIdentifier)
+		] as CFDictionary
+
+		var guestCode: SecCode?
+		let resolveStatus = SecCodeCopyGuestWithAttributes(nil, attributes, [], &guestCode)
+		guard resolveStatus == errSecSuccess,
+		      let guestCode else {
+			os_log(
+				"Rejecting XPC client: unable to resolve code for pid %{public}d (OSStatus %{public}d)",
+				type: .error,
+				processIdentifier,
+				resolveStatus
+			)
+			return false
+		}
+
+		guard requirementState.status == errSecSuccess,
+		      let requirement = requirementState.requirement else {
+			os_log(
+				"Rejecting XPC client: unable to create its code-signing requirement (OSStatus %{public}d)",
+				type: .error,
+				requirementState.status
+			)
+			return false
+		}
+
+		let validationStatus = SecCodeCheckValidity(
+			guestCode,
+			SecCSFlags(rawValue: kSecCSStrictValidate),
+			requirement
+		)
+		guard validationStatus == errSecSuccess else {
+			os_log(
+				"Rejecting XPC client: invalid ClashX Meta code signature (OSStatus %{public}d)",
+				type: .error,
+				validationStatus
+			)
+			return false
+		}
+
+		return true
+	}
+}

--- a/ProxyConfigHelper/ProxyConfigHelper.swift
+++ b/ProxyConfigHelper/ProxyConfigHelper.swift
@@ -54,11 +54,10 @@ class ProxyConfigHelper: NSObject, NSXPCListenerDelegate {
 	// MARK: - NSXPCListenerDelegate
 	
 	func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
-		
-		guard isValid(connection: newConnection) else {
+		guard HelperXPCSecurity.isValid(processIdentifier: newConnection.processIdentifier) else {
 			return false
 		}
-		
+
 		newConnection.exportedInterface = NSXPCInterface(with: ProxyConfigRemoteProcessProtocol.self)
 		newConnection.exportedObject = self
 		newConnection.invalidationHandler = {
@@ -74,16 +73,6 @@ class ProxyConfigHelper: NSObject, NSXPCListenerDelegate {
 		connections.append(newConnection)
 		newConnection.resume()
 		
-		return true
-	}
-	
-	private func isValid(connection: NSXPCConnection) -> Bool {
-		guard let app = NSRunningApplication(processIdentifier: connection.processIdentifier),
-			  let bundleIdentifier = app.bundleIdentifier,
-			  bundleIdentifier == "com.metacubex.ClashX.meta"
-		else {
-			return false
-		}
 		return true
 	}
 	

--- a/Tests/HelperXPCSecurity/HelperXPCSecurityTest.swift
+++ b/Tests/HelperXPCSecurity/HelperXPCSecurityTest.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+@main
+private enum HelperXPCSecurityTest {
+	static func main() {
+		guard CommandLine.arguments.count == 2 else {
+			fatalError("Expected accepted or rejected")
+		}
+
+		let expected = CommandLine.arguments[1]
+		let accepted = HelperXPCSecurity.isValid(processIdentifier: getpid())
+
+		switch (expected, accepted) {
+		case ("accepted", true), ("rejected", false):
+			print("PASS: connection was \(expected)")
+		case ("accepted", false):
+			fatalError("Authorized client was rejected")
+		case ("rejected", true):
+			fatalError("Unauthorized client was accepted")
+		default:
+			fatalError("Expected accepted or rejected")
+		}
+	}
+}

--- a/Tests/HelperXPCSecurity/run.sh
+++ b/Tests/HelperXPCSecurity/run.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+set -eu
+
+readonly repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+readonly security_source="$repo_root/ProxyConfigHelper/HelperXPCSecurity.swift"
+readonly test_source="$repo_root/Tests/HelperXPCSecurity/HelperXPCSecurityTest.swift"
+readonly build_dir=$(mktemp -d)
+readonly test_binary="$build_dir/helper-xpc-security-test"
+
+cleanup() {
+	rm -rf "$build_dir"
+}
+trap cleanup EXIT
+
+swiftc ${=CLASHX_SWIFTC_FLAGS:-} "$test_source" "$security_source" -framework Security -o "$test_binary"
+
+codesign --force --sign - --identifier com.metacubex.ClashX.meta "$test_binary"
+"$test_binary" accepted
+
+codesign --force --sign - --identifier com.example.unauthorized "$test_binary"
+"$test_binary" rejected


### PR DESCRIPTION
## Summary

- Resolve helper XPC clients through Security.framework.
- Validate the connecting client before accepting the XPC connection.
- Add regression coverage for accepted and rejected client identifiers.

## Why

When the helper runs as a privileged launch daemon, `NSRunningApplication` may not provide the connecting application's bundle identifier. This rejects a valid ClashX Meta connection and can trigger repeated helper installation prompts on macOS Tahoe.

The new validation resolves the live process through Security.framework and checks its signing identifier before accepting the connection.

## Testing

- Ran `Tests/HelperXPCSecurity/run.sh`.
  - Verified that the ClashX Meta identifier is accepted.
  - Verified that an unrelated identifier is rejected.
- Built the Helper target in Release configuration as a universal arm64 and x86_64 binary with Xcode 27.
- Manually verified the packaged build on a second Mac: the helper installed and connected without repeated prompts.

Fixes #209
